### PR TITLE
Feat/support matrix UI

### DIFF
--- a/src/common_vec_op/gen.rs
+++ b/src/common_vec_op/gen.rs
@@ -40,10 +40,11 @@ impl IVisData for VecLineData {
                 matrix[2][0], matrix[2][1], matrix[2][2],
             ];
             let [x, y, z] = point;
+            let z_ = g * x + h * y + i * z;
             [
-                a * x + b * y + c * z,
-                d * x + e * y + f * z,
-                g * x + h * y + i * z,
+                (a * x + b * y + c * z) / z_,
+                (d * x + e * y + f * z) / z_,
+                1.0,
             ]
         }
         let [x, y, _] = mul_point(matrix, [self.x, self.y, 1.0]);

--- a/src/main.rs
+++ b/src/main.rs
@@ -266,21 +266,21 @@ impl MainApp {
                                         .horizontal(|mut strip| {
                                             strip.cell(|ui| {
                                                 ui.add_sized(ui.available_size(),
-                                                             egui::Slider::new(&mut self.params.trans_matrix[2][0], -500.0..=500.0)
+                                                             egui::Slider::new(&mut self.params.trans_matrix[2][0], -5.0..=5.0)
                                                                  .text("m20")
                                                                  .show_value(true),
                                                 );
                                             });
                                             strip.cell(|ui| {
                                                 ui.add_sized(ui.available_size(),
-                                                             egui::Slider::new(&mut self.params.trans_matrix[2][1], -500.0..=500.0)
+                                                             egui::Slider::new(&mut self.params.trans_matrix[2][1], -5.0..=5.0)
                                                                  .text("m21")
                                                                  .show_value(true),
                                                 );
                                             });
                                             strip.cell(|ui| {
                                                 ui.add_sized(ui.available_size(),
-                                                             egui::Slider::new(&mut self.params.trans_matrix[2][2], -5.0..=5.0)
+                                                             egui::Slider::new(&mut self.params.trans_matrix[2][2], -500.0..=500.0)
                                                                  .text("m22")
                                                                  .show_value(true),
                                                 );

--- a/src/main.rs
+++ b/src/main.rs
@@ -222,7 +222,7 @@ impl MainApp {
                                             });
                                             strip.cell(|ui| {
                                                 ui.add_sized(ui.available_size(),
-                                                             egui::Slider::new(&mut self.params.trans_matrix[0][2], -100.0..=100.0)
+                                                             egui::Slider::new(&mut self.params.trans_matrix[0][2], -500.0..=500.0)
                                                                  .text("m02")
                                                                  .show_value(true),
                                                 );
@@ -251,7 +251,7 @@ impl MainApp {
                                             });
                                             strip.cell(|ui| {
                                                 ui.add_sized(ui.available_size(),
-                                                             egui::Slider::new(&mut self.params.trans_matrix[1][2], -100.0..=100.0)
+                                                             egui::Slider::new(&mut self.params.trans_matrix[1][2], -500.0..=500.0)
                                                                  .text("m12")
                                                                  .show_value(true),
                                                 );
@@ -266,14 +266,14 @@ impl MainApp {
                                         .horizontal(|mut strip| {
                                             strip.cell(|ui| {
                                                 ui.add_sized(ui.available_size(),
-                                                             egui::Slider::new(&mut self.params.trans_matrix[2][0], -5.0..=5.0)
+                                                             egui::Slider::new(&mut self.params.trans_matrix[2][0], -500.0..=500.0)
                                                                  .text("m20")
                                                                  .show_value(true),
                                                 );
                                             });
                                             strip.cell(|ui| {
                                                 ui.add_sized(ui.available_size(),
-                                                             egui::Slider::new(&mut self.params.trans_matrix[2][1], -5.0..=5.0)
+                                                             egui::Slider::new(&mut self.params.trans_matrix[2][1], -500.0..=500.0)
                                                                  .text("m21")
                                                                  .show_value(true),
                                                 );

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,7 +37,7 @@ const COLOR_PALETTE: [egui::Color32; 10] = [
 fn main() -> Result<(), eframe::Error> {
     env_logger::init(); // Log to stderr (if you run with `RUST_LOG=debug`).
     let options = eframe::NativeOptions {
-        initial_window_size: Some(egui::vec2(960.0, 640.0)),
+        initial_window_size: Some(egui::vec2(1440.0, 960.0)),
         ..Default::default()
     };
     eframe::run_native(
@@ -54,7 +54,7 @@ struct MainAppCache {
     params: MainAppParams,
 }
 
-#[derive(Clone, PartialEq, Default)]
+#[derive(Clone, PartialEq)]
 struct MainAppParams {
     vis_progress: i64,
     vis_progress_max: i64,
@@ -64,6 +64,23 @@ struct MainAppParams {
     colorful_block: bool,
 
     trans_matrix: [[f64; 3]; 3],
+}
+
+impl Default for MainAppParams {
+    fn default() -> Self {
+        Self {
+            vis_progress: 0,
+            vis_progress_max: 0,
+            lcd_coords: false,
+            show_inter_dash: false,
+            colorful_block: false,
+            trans_matrix: [
+                [1.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0],
+                [0.0, 0.0, 1.0],
+            ], // Identity matrix
+        }
+    }
 }
 
 struct MainApp {
@@ -92,12 +109,6 @@ impl Default for MainApp {
 
 impl eframe::App for MainApp {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
-        self.params.trans_matrix = [
-            [1.0, 0.0, 0.0],
-            [0.0, 1.0, 0.0],
-            [0.0, 0.0, 1.0],
-        ]; // Identity matrix
-
         egui::CentralPanel::default().show(ctx, |ui| {
             StripBuilder::new(ui)
                 .size(Size::exact(30.0))
@@ -119,7 +130,7 @@ impl eframe::App for MainApp {
                                 });
                                 strip.strip(|builder| {
                                     builder
-                                        .size(Size::exact(60.0))
+                                        .size(Size::exact(180.0))
                                         .size(Size::exact(30.0))
                                         .size(Size::remainder())
                                         .vertical(|mut strip| {
@@ -174,6 +185,111 @@ impl MainApp {
                                  .show_value(true),
                 );
             });
+            StripBuilder::new(ui)
+                .size(Size::exact(30.0))
+                .size(Size::remainder())
+                .vertical(|mut strip| {
+                    strip.cell(|ui| {
+                        ui.vertical_centered(|ui| {
+                            ui.heading("Transform Matrix");
+                        });
+                    });
+                    strip.strip(|builder| {
+                        builder
+                            .size(Size::exact(20.0))
+                            .size(Size::exact(20.0))
+                            .size(Size::exact(20.0)) // 3x3 matrix
+                            .vertical(|mut strip| {
+                                strip.strip(|builder| {
+                                    builder
+                                        .size(Size::relative(0.33))
+                                        .size(Size::relative(0.33))
+                                        .size(Size::relative(0.33)) // 3x3 matrix
+                                        .horizontal(|mut strip| {
+                                            strip.cell(|ui| {
+                                                ui.add_sized(ui.available_size(),
+                                                             egui::Slider::new(&mut self.params.trans_matrix[0][0], -5.0..=5.0)
+                                                                 .text("m00")
+                                                                 .show_value(true),
+                                                );
+                                            });
+                                            strip.cell(|ui| {
+                                                ui.add_sized(ui.available_size(),
+                                                             egui::Slider::new(&mut self.params.trans_matrix[0][1], -5.0..=5.0)
+                                                                 .text("m01")
+                                                                 .show_value(true),
+                                                );
+                                            });
+                                            strip.cell(|ui| {
+                                                ui.add_sized(ui.available_size(),
+                                                             egui::Slider::new(&mut self.params.trans_matrix[0][2], -100.0..=100.0)
+                                                                 .text("m02")
+                                                                 .show_value(true),
+                                                );
+                                            });
+                                        });
+                                });
+                                strip.strip(|builder| {
+                                    builder
+                                        .size(Size::relative(0.33))
+                                        .size(Size::relative(0.33))
+                                        .size(Size::relative(0.33)) // 3x3 matrix
+                                        .horizontal(|mut strip| {
+                                            strip.cell(|ui| {
+                                                ui.add_sized(ui.available_size(),
+                                                             egui::Slider::new(&mut self.params.trans_matrix[1][0], -5.0..=5.0)
+                                                                 .text("m10")
+                                                                 .show_value(true),
+                                                );
+                                            });
+                                            strip.cell(|ui| {
+                                                ui.add_sized(ui.available_size(),
+                                                             egui::Slider::new(&mut self.params.trans_matrix[1][1], -5.0..=5.0)
+                                                                 .text("m11")
+                                                                 .show_value(true),
+                                                );
+                                            });
+                                            strip.cell(|ui| {
+                                                ui.add_sized(ui.available_size(),
+                                                             egui::Slider::new(&mut self.params.trans_matrix[1][2], -100.0..=100.0)
+                                                                 .text("m12")
+                                                                 .show_value(true),
+                                                );
+                                            });
+                                        });
+                                });
+                                strip.strip(|builder| {
+                                    builder
+                                        .size(Size::relative(0.33))
+                                        .size(Size::relative(0.33))
+                                        .size(Size::relative(0.33)) // 3x3 matrix
+                                        .horizontal(|mut strip| {
+                                            strip.cell(|ui| {
+                                                ui.add_sized(ui.available_size(),
+                                                             egui::Slider::new(&mut self.params.trans_matrix[2][0], -5.0..=5.0)
+                                                                 .text("m20")
+                                                                 .show_value(true),
+                                                );
+                                            });
+                                            strip.cell(|ui| {
+                                                ui.add_sized(ui.available_size(),
+                                                             egui::Slider::new(&mut self.params.trans_matrix[2][1], -5.0..=5.0)
+                                                                 .text("m21")
+                                                                 .show_value(true),
+                                                );
+                                            });
+                                            strip.cell(|ui| {
+                                                ui.add_sized(ui.available_size(),
+                                                             egui::Slider::new(&mut self.params.trans_matrix[2][2], -5.0..=5.0)
+                                                                 .text("m22")
+                                                                 .show_value(true),
+                                                );
+                                            });
+                                        });
+                                });
+                            });
+                    });
+                });
         });
     }
 


### PR DESCRIPTION
Support 2.5D matrix transformation such as apply a matrix like

```
[0.899414,  0.075757, 126.720360],
[-0.000000, 0.896413, 172.393127],
[-0.000000, 0.000370, 0.951589],
```

It will shows some perspective effect for this content on the canvas.